### PR TITLE
fix(routing): correct useFilterWithQS usage

### DIFF
--- a/app/(datasets)/data-catalog/catalog.tsx
+++ b/app/(datasets)/data-catalog/catalog.tsx
@@ -1,14 +1,12 @@
 'use client';
 import React from 'react';
 import { CatalogView, useFiltersWithQS } from '@lib';
-import { useRouter } from 'next/navigation';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 
 export default function Catalog({ datasets }: { datasets: any }) {
-  const router = useRouter();
   const pathname = usePathname();
-  const controlVars = useFiltersWithQS({ navigate: router, push: true });
+  const controlVars = useFiltersWithQS();
 
   return (
     <CatalogView


### PR DESCRIPTION
In https://github.com/NASA-IMPACT/veda-ui/pull/1270, we updated the interface of `useFilterWithQS` by removing the requirement to pass `router.navigate` to the hook.

@dzole0311, you already tested this while reviewing the upstream PR. Could you give this a quick look? 