### PR TITLE
Push Providers down and other optimizations

### DIFF
--- a/app/(datasets)/data-catalog/[slug]/page.tsx
+++ b/app/(datasets)/data-catalog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { CustomMDX } from 'app/components/mdx';
 import { getDatasets } from 'app/content/utils/mdx';
 import { baseUrl } from 'app/sitemap';
 import { PageHero } from '@lib';
+import Providers from 'app/(datasets)/providers';
 
 function generateStaticParams() {
   const posts = getDatasets();
@@ -51,7 +52,6 @@ export function generateMetadata({ params }) {
 
 export default function Blog({ params }: { params: any }) {
   const post = getDatasets().find((post) => post.slug === params.slug);
-
   if (!post) {
     notFound();
   }
@@ -59,12 +59,14 @@ export default function Blog({ params }: { params: any }) {
   return (
     <section>
       <article className='prose'>
-        <PageHero
-          title={post.metadata.name}
-          description={post.metadata.description}
-          coverSrc={post.metadata.media?.src}
-          coverAlt={post.metadata.media?.alt}
-        />
+        <Providers>
+          <PageHero
+            title={post.metadata.name}
+            description={post.metadata.description}
+            coverSrc={post.metadata.media?.src}
+            coverAlt={post.metadata.media?.alt}
+          />
+        </Providers>
         <CustomMDX source={post.content} />
       </article>
     </section>

--- a/app/(datasets)/data-catalog/catalog.tsx
+++ b/app/(datasets)/data-catalog/catalog.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { CatalogView, useFiltersWithQS } from '@lib';
 import { useRouter } from 'next/navigation';
+import Providers from '../providers';
 
 export default function Catalog({ datasets }: { datasets: any }) {
   const controlVars = useFiltersWithQS();
@@ -12,10 +13,12 @@ export default function Catalog({ datasets }: { datasets: any }) {
   };
 
   return (
-    <CatalogView
-      datasets={datasets}
-      onFilterChanges={() => controlVars}
-      onCardNavigate={handleCardNavigation}
-    />
+    <Providers>
+      <CatalogView
+        datasets={datasets}
+        onFilterChanges={() => controlVars}
+        onCardNavigate={handleCardNavigation}
+      />
+    </Providers>
   );
 }

--- a/app/(datasets)/data-catalog/page.tsx
+++ b/app/(datasets)/data-catalog/page.tsx
@@ -9,6 +9,7 @@ export default function Page() {
   return (
     <div className='grid-container'>
       <section>
+        <h1 className='font-ui-lg'>Data Catalog</h1>
         <Suspense fallback={<>Loading...</>}>
           <Catalog datasets={transformed} />
         </Suspense>

--- a/app/(datasets)/data-catalog/page.tsx
+++ b/app/(datasets)/data-catalog/page.tsx
@@ -1,7 +1,15 @@
 import React from 'react';
+import dynamic from 'next/dynamic';
 import { getTransformedDatasetMetadata } from 'app/content/utils/mdx';
 import { Suspense } from 'react';
-import Catalog from './catalog';
+
+const Catalog = dynamic(
+  () => import('./catalog'),
+  { 
+    ssr: false,
+    loading: () => <p>Loading...</p> // @NOTE @TODO: We need a loading state!!!
+  },
+);
 
 export default function Page() {
   const transformed = getTransformedDatasetMetadata();

--- a/app/(datasets)/exploration/exploration.tsx
+++ b/app/(datasets)/exploration/exploration.tsx
@@ -7,9 +7,9 @@ import {
   useTimelineDatasetAtom,
   externalDatasetsAtom,
 } from 'app/lib';
-
 import { useSetAtom } from 'jotai';
 import useElementHeight from '@utils/hooks/use-element-height';
+import Providers from '../providers';
 
 export default function ExplorationAnalysis({ datasets }: { datasets: any }) {
   const setExternalDatasets = useSetAtom(externalDatasetsAtom);
@@ -31,34 +31,35 @@ export default function ExplorationAnalysis({ datasets }: { datasets: any }) {
   const offsetHeight = useElementHeight({ queryToSelect: 'header' });
 
   return (
-    <div
-      id='ea-wrapper'
-      // The below styles adjust the E&A page to match what we have on earthdata.nasa.gov
-      // E&A is supposed to fill up whichever space given
-      // Adjusting the container's height so the page with E&A doesn't overflow.
-      style={{
-        width: '100%',
-        height: `calc(100vh - ${offsetHeight}px)`,
-      }}
-    >
-      <DatasetSelectorModal
-        revealed={datasetModalRevealed}
-        close={closeModal}
-        linkProperties={{
-          LinkElement: Link,
-          pathAttributeKeyName: 'href',
+    <Providers datasets={datasets}>
+      <div
+        id='ea-wrapper'
+        // The below styles adjust the E&A page to match what we have on earthdata.nasa.gov
+        // E&A is supposed to fill up whichever space given
+        // Adjusting the container's height so the page with E&A doesn't overflow.
+        style={{
+          width: '100%',
+          height: `calc(100vh - ${offsetHeight}px)`,
         }}
-        timelineDatasets={timelineDatasets}
-        setTimelineDatasets={setTimelineDatasets}
-        datasetPathName={'data-catalog'}
-        datasets={datasets}
-      />
-
-      <ExplorationAndAnalysis
-        datasets={timelineDatasets}
-        setDatasets={setTimelineDatasets}
-        openDatasetsSelectionModal={openModal}
-      />
-    </div>
+      >
+        <DatasetSelectorModal
+          revealed={datasetModalRevealed}
+          close={closeModal}
+          linkProperties={{
+            LinkElement: Link,
+            pathAttributeKeyName: 'href',
+          }}
+          timelineDatasets={timelineDatasets}
+          setTimelineDatasets={setTimelineDatasets}
+          datasetPathName={'data-catalog'}
+          datasets={datasets}
+        />
+        <ExplorationAndAnalysis
+          datasets={timelineDatasets}
+          setDatasets={setTimelineDatasets}
+          openDatasetsSelectionModal={openModal}
+        />
+      </div>
+    </Providers>
   );
 }

--- a/app/(datasets)/exploration/page.tsx
+++ b/app/(datasets)/exploration/page.tsx
@@ -1,15 +1,24 @@
 import React, { Suspense } from 'react';
+import dynamic from 'next/dynamic';
 import { getTransformedDatasetMetadata } from 'app/content/utils/mdx';
-import ExplorationAnalysis from './exploration';
-import { PageHero } from 'app/lib';
+import Providers from '../providers';
+
+const ExplorationAnalysis = dynamic(
+  () => import('./exploration'),
+  { 
+    ssr: false,
+    loading: () => <p>Loading...</p> // @NOTE @TODO: We need a loading state!!!
+  },
+);
 
 export default function Page() {
   const datasets: any[] = getTransformedDatasetMetadata();
   return (
     <section>
       <Suspense fallback={<>Loading...</>}>
-        <PageHero title='Exploration' isHidden />
-        <ExplorationAnalysis datasets={datasets} />
+        <Providers datasets={datasets}>
+          <ExplorationAnalysis datasets={datasets} />
+        </Providers>
       </Suspense>
     </section>
   );

--- a/app/(datasets)/exploration/page.tsx
+++ b/app/(datasets)/exploration/page.tsx
@@ -1,7 +1,6 @@
 import React, { Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import { getTransformedDatasetMetadata } from 'app/content/utils/mdx';
-import Providers from '../providers';
 
 const ExplorationAnalysis = dynamic(
   () => import('./exploration'),
@@ -16,9 +15,7 @@ export default function Page() {
   return (
     <section>
       <Suspense fallback={<>Loading...</>}>
-        <Providers datasets={datasets}>
-          <ExplorationAnalysis datasets={datasets} />
-        </Providers>
+        <ExplorationAnalysis datasets={datasets} />
       </Suspense>
     </section>
   );

--- a/app/(datasets)/layout.tsx
+++ b/app/(datasets)/layout.tsx
@@ -1,23 +1,43 @@
+// NOTE-SANDRA: We dont need this anymore for right now because we may want to explore just 
+// wrapping the providers directly around our client-side veda-ui library component
+
+
 import React, { ReactNode } from 'react';
-import DataProvider from 'app/store/providers/data';
-import { getDatasetsMetadata } from 'app/content/utils/mdx';
-import VedaUIConfigProvider from 'app/store/providers/veda-ui';
-import DevseedUIThemeProvider from 'app/store/providers/theme';
+// import DataProvider from 'app/store/providers/data';
+// import { getDatasetsMetadata } from 'app/content/utils/mdx';
+// import VedaUIConfigProvider from 'app/store/providers/veda-ui';
+// import DevseedUIThemeProvider from 'app/store/providers/theme';
+
+// export default function DatasetLayout({
+//   children,
+// }: {
+//   children: JSX.Element | ReactNode;
+// }) {
+//   const datasets = getDatasetsMetadata();
+
+//   return (
+//     <DevseedUIThemeProvider>
+//       <VedaUIConfigProvider>
+//         <DataProvider initialDatasets={datasets}>
+//           {children}
+//         </DataProvider>
+//       </VedaUIConfigProvider>
+//     </DevseedUIThemeProvider>
+//   );
+// }
 
 export default function DatasetLayout({
   children,
 }: {
   children: JSX.Element | ReactNode;
 }) {
-  const datasets = getDatasetsMetadata();
-
+  // const datasets = getDatasetsMetadata();
   return (
-    <DevseedUIThemeProvider>
-      <VedaUIConfigProvider>
-        <DataProvider initialDatasets={datasets}>
-          {children}
-        </DataProvider>
-      </VedaUIConfigProvider>
-    </DevseedUIThemeProvider>
+      // <DataProvider initialDatasets={datasets}>
+      <>
+      {children}
+      </>
+      // </DataProvider>
   );
 }
+

--- a/app/(datasets)/layout.tsx
+++ b/app/(datasets)/layout.tsx
@@ -1,6 +1,8 @@
 import React, { ReactNode } from 'react';
 import DataProvider from 'app/store/providers/data';
 import { getDatasetsMetadata } from 'app/content/utils/mdx';
+import VedaUIConfigProvider from 'app/store/providers/veda-ui';
+import DevseedUIThemeProvider from 'app/store/providers/theme';
 
 export default function DatasetLayout({
   children,
@@ -9,5 +11,13 @@ export default function DatasetLayout({
 }) {
   const datasets = getDatasetsMetadata();
 
-  return <DataProvider initialDatasets={datasets}>{children}</DataProvider>;
+  return (
+    <DevseedUIThemeProvider>
+      <VedaUIConfigProvider>
+        <DataProvider initialDatasets={datasets}>
+          {children}
+        </DataProvider>
+      </VedaUIConfigProvider>
+    </DevseedUIThemeProvider>
+  );
 }

--- a/app/(datasets)/providers.tsx
+++ b/app/(datasets)/providers.tsx
@@ -1,0 +1,28 @@
+import React, { ReactNode } from 'react';
+import DataProvider from 'app/store/providers/data';
+import VedaUIConfigProvider from 'app/store/providers/veda-ui';
+import DevseedUIThemeProvider from 'app/store/providers/theme';
+
+export default function Providers ({
+  datasets,
+  children
+}: {
+  datasets?: any,
+  children: ReactNode
+}) {
+  return (
+    <DevseedUIThemeProvider>
+      <VedaUIConfigProvider>
+        {
+          datasets ? (
+            <DataProvider initialDatasets={datasets}>
+              {children}
+            </DataProvider>
+          ) : (
+            children
+          )
+        }
+      </VedaUIConfigProvider>
+    </DevseedUIThemeProvider>
+  )
+}

--- a/app/(datasets)/stories/hub.tsx
+++ b/app/(datasets)/stories/hub.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { StoriesHubContent, useFiltersWithQS } from '@lib';
 import Link from 'next/link';
-
+import Providers from '../providers';
 
 export default function Hub({
   stories: allStories
@@ -12,18 +12,20 @@ export default function Hub({
   const controlVars = useFiltersWithQS();
 
   return (
-    <StoriesHubContent
-      allStories={allStories}
-      onFilterchanges={() => controlVars}
-      storiesString= {{
-        one: 'story',
-        other: 'stories'
-      }}
-      linkProperties={{
-        LinkElement: Link,
-        pathAttributeKeyName: 'href'
-      }}
-      storiesPagePath={'stories'}
-    />
+    <Providers>
+      <StoriesHubContent
+        allStories={allStories}
+        onFilterchanges={() => controlVars}
+        storiesString= {{
+          one: 'story',
+          other: 'stories'
+        }}
+        linkProperties={{
+          LinkElement: Link,
+          pathAttributeKeyName: 'href'
+        }}
+        storiesPagePath={'stories'}
+      />
+    </Providers>
   );
 }

--- a/app/(datasets)/stories/page.tsx
+++ b/app/(datasets)/stories/page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { getStoriesMetadata } from 'app/content/utils/mdx';
 import Hub from './hub';
 
@@ -9,10 +9,13 @@ export default function Page() {
   }));
 
   return (
-    <section>
-      <div className='grid-container'>
-        <Hub stories={stories} />
-      </div>
-    </section>
+    <div className='grid-container'>
+      <section>
+        <h1 className='font-ui-lg'>Stories</h1>
+        <Suspense fallback={<>Loading...</>}>
+          <Hub stories={stories} />
+        </Suspense>
+      </section>
+    </div>
   );
 }

--- a/app/(datasets)/stories/page.tsx
+++ b/app/(datasets)/stories/page.tsx
@@ -1,6 +1,14 @@
 import React, { Suspense } from 'react';
+import dynamic from 'next/dynamic';
 import { getStoriesMetadata } from 'app/content/utils/mdx';
-import Hub from './hub';
+
+const StoriesHub = dynamic(
+  () => import('./hub'),
+  { 
+    ssr: false,
+    loading: () => <p>Loading...</p> // @NOTE @TODO: We need a loading state!!!
+  },
+);
 
 export default function Page() {
   const stories = getStoriesMetadata().map((d) => ({
@@ -13,7 +21,7 @@ export default function Page() {
       <section>
         <h1 className='font-ui-lg'>Stories</h1>
         <Suspense fallback={<>Loading...</>}>
-          <Hub stories={stories} />
+          <StoriesHub stories={stories} />
         </Suspense>
       </section>
     </div>

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { navItems, subNavItems } from './header';
 import NasaLogoColor from './nasa-logo-color';
 import { PageFooter } from '@lib';
+import VedaUIConfigProvider from 'app/store/providers/veda-ui';
 
 export default function Footer() {
   const defaultFooterSettings = {
@@ -17,13 +18,15 @@ export default function Footer() {
     returnToTop: true,
   };
   return (
-    <PageFooter
-      mainNavItems={navItems}
-      subNavItems={subNavItems}
-      hideFooter={false}
-      logoSvg={<NasaLogoColor />}
-      linkProperties={{ LinkElement: Link, pathAttributeKeyName: 'href' }}
-      footerSettings={defaultFooterSettings}
-    />
+    <VedaUIConfigProvider>
+      <PageFooter
+        mainNavItems={navItems}
+        subNavItems={subNavItems}
+        hideFooter={false}
+        logoSvg={<NasaLogoColor />}
+        linkProperties={{ LinkElement: Link, pathAttributeKeyName: 'href' }}
+        footerSettings={defaultFooterSettings}
+      />
+    </VedaUIConfigProvider>
   );
 }

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import Link from 'next/link';
 import { PageHeader } from '@lib';
 import { NavItem } from '@lib';
 import NasaLogoColor from 'app/components/nasa-logo-color.js';
+import VedaUIConfigProvider from 'app/store/providers/veda-ui';
 
 
 export const navItems: NavItem[] = [
@@ -42,27 +42,24 @@ export const subNavItems: NavItem[] = [
 ]
 
 export default function Header() {
-  const linkProps = {
-    LinkElement: Link,
-    pathAttributeKeyName: 'href',
-  };
-
   return (
-    <PageHeader
-      mainNavItems={navItems}
-      subNavItems={subNavItems}
-      logoSvg={
-        <div id='logo-container-link'>
-          {/*
-            USWDS targets only <a> tags for styling links. However when the text is a <span>
-            instead of a link, it does not inherit the color styling (it ends up being white).
-            To fix this, we must add the color inline like this.
-            TODO: Ideally we can address this on the veda-ui side so that the color applies to all elements within the logo.
-          */}
-          <NasaLogoColor />
-          <span style={{ color: '#1b1b1b' }}>Earthdata VEDA Dashboard</span>
-        </div>
-      }
-    />
+    <VedaUIConfigProvider>
+      <PageHeader
+        mainNavItems={navItems}
+        subNavItems={subNavItems}
+        title='Earthdata VEDA Dashboard'
+        logoSvg={
+          <div id='logo-container-link'>
+            {/*
+              USWDS targets only <a> tags for styling links. However when the text is a <span>
+              instead of a link, it does not inherit the color styling (it ends up being white).
+              To fix this, we must add the color inline like this.
+              TODO: Ideally we can address this on the veda-ui side so that the color applies to all elements within the logo.
+            */}
+            <NasaLogoColor />
+          </div>
+        }
+      />
+    </VedaUIConfigProvider>
   );
 }

--- a/app/components/mdx.tsx
+++ b/app/components/mdx.tsx
@@ -5,6 +5,8 @@ import { highlight } from 'sugar-high';
 
 import { Block, Prose, Caption, Chapter, Figure, Image, CompareImage, Chart } from '@lib';
 import { EnhancedMapBlock, EnhancedScrollyTellingBlock } from './mdx-components/block';
+import { getDatasetsMetadata } from 'app/content/utils/mdx';
+import Providers from 'app/(datasets)/providers';
 
 function Table({ data }: { data: any }) {
   const headers = data.headers.map((header, index) => (
@@ -89,12 +91,15 @@ const components = {
 };
 
 export function CustomMDX(props: any) {
+  const datasets = getDatasetsMetadata();
   return (
-    <MDXRemote
-      {...props}
-      components={{ ...components, ...(props.components || {}) }}
-    >
-      {props.children}
-    </MDXRemote>
+    <Providers datasets={datasets}>
+      <MDXRemote
+        {...props}
+        components={{ ...components, ...(props.components || {}) }}
+      >
+        {props.children}
+      </MDXRemote>
+    </Providers>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,18 +1,22 @@
 import React from 'react';
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import Header from './components/header';
 import { baseUrl } from './sitemap';
 import dynamic from 'next/dynamic';
-import { VedaUIProvider } from '@lib';
 import Footer from './components/footer';
 
 import './styles/index.scss';
 
 import '@teamimpact/veda-ui/lib/main.css';
 
+// @NOTE: Conditionally load provider to make sure its only CSR
 const DevSeedUIThemeProvider = dynamic(
   () => import('app/store/providers/theme'),
+  { ssr: false },
+);
+
+const VedaUIConfigProvider = dynamic(
+  () => import('app/store/providers/veda-ui'),
   { ssr: false },
 );
 
@@ -53,27 +57,13 @@ export default function RootLayout({
     <html lang='en'>
       <body>
         <DevSeedUIThemeProvider>
-          <VedaUIProvider
-            config={{
-              envMapboxToken: process.env.NEXT_PUBLIC_MAPBOX_TOKEN ?? '',
-              envApiStacEndpoint:
-                process.env.NEXT_PUBLIC_API_STAC_ENDPOINT ?? '',
-              envApiRasterEndpoint:
-                process.env.NEXT_PUBLIC_API_RASTER_ENDPOINT ?? '',
-              navigation: {
-                LinkComponent: Link,
-                linkProps: {
-                  pathAttributeKeyName: 'href',
-                },
-              },
-            }}
-          >
+          <VedaUIConfigProvider>
             <div className='minh-viewport display-flex flex-column'>
               <Header />
               <div className='flex-fill'>{children}</div>
               <Footer />
             </div>
-          </VedaUIProvider>
+          </VedaUIConfigProvider>
         </DevSeedUIThemeProvider>
       </body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,24 +1,27 @@
 import React from 'react';
 import type { Metadata } from 'next';
-import Header from './components/header';
 import { baseUrl } from './sitemap';
 import dynamic from 'next/dynamic';
-import Footer from './components/footer';
-
 import './styles/index.scss';
-
 import '@teamimpact/veda-ui/lib/main.css';
 
-// @NOTE: Conditionally load provider to make sure its only CSR
-const DevSeedUIThemeProvider = dynamic(
-  () => import('app/store/providers/theme'),
-  { ssr: false },
+// @NOTE: Dynamically load to ensure only CSR since these depends on VedaUI ContextProvider for routing
+const Header = dynamic(
+  () => import('./components/header'),
+  { 
+    ssr: false,
+    loading: () => <p>Loading...</p> // @NOTE @TODO: We need a loading state!!!
+  },
 );
 
-const VedaUIConfigProvider = dynamic(
-  () => import('app/store/providers/veda-ui'),
-  { ssr: false },
+const Footer = dynamic(
+  () => import('./components/footer'),
+  { 
+    ssr: false,
+    loading: () => <p>Loading...</p>
+  },
 );
+
 
 export const metadata: Metadata = {
   metadataBase: new URL(baseUrl),
@@ -56,15 +59,11 @@ export default function RootLayout({
   return (
     <html lang='en'>
       <body>
-        <DevSeedUIThemeProvider>
-          <VedaUIConfigProvider>
-            <div className='minh-viewport display-flex flex-column'>
-              <Header />
-              <div className='flex-fill'>{children}</div>
-              <Footer />
-            </div>
-          </VedaUIConfigProvider>
-        </DevSeedUIThemeProvider>
+        <div className='min-viewport display-flex flex-column'>
+          <Header />
+          <div className='flex-fill'>{children}</div>
+          <Footer />
+        </div>
       </body>
     </html>
   );

--- a/app/store/providers/veda-ui.tsx
+++ b/app/store/providers/veda-ui.tsx
@@ -1,0 +1,28 @@
+'use client';
+import React from 'react';
+import Link from 'next/link';
+import { VedaUIProvider } from '@lib';
+
+export default function VedaUIConfigProvider({children}: {
+  children: any;
+}) {
+  return (
+    <VedaUIProvider
+      config={{
+        envMapboxToken: process.env.NEXT_PUBLIC_MAPBOX_TOKEN ?? '',
+        envApiStacEndpoint:
+          process.env.NEXT_PUBLIC_API_STAC_ENDPOINT ?? '',
+        envApiRasterEndpoint:
+          process.env.NEXT_PUBLIC_API_RASTER_ENDPOINT ?? '',
+        navigation: {
+          LinkComponent: Link,
+          linkProps: {
+            pathAttributeKeyName: 'href',
+          },
+        },
+      }}
+    >
+        {children}
+    </VedaUIProvider>
+  )
+}


### PR DESCRIPTION
https://github.com/NASA-IMPACT/veda-ui/issues/1428

@AliceR Here is a summary of things I tried to play around with in this PR. Its not a ready PR**, lots of things commented out but created this branch to start.

**Changes in this branch:**
1. I moved took all the providers and moved them out of global layout into a providers file so no longer global. Also got rid of dynamic layout in `/(datasets)/*` path.
2. I pushed our Providers down the tree to wrap only what needed them. Home & About as well as static html renders (added title headings with uswds styling to see if it would render) with javascript disabled. _I'm not sure if we really want to do this but it makes sense to just wrap whatever needed it down the tree and not our server components with it. But usually Providers are wrapped at the highest level... so it feels weird doing this.. lmk what you think._
3. Played around with Dynamic imports which we have used before but I think we could flush out their use more. I didn't do so much with it so maybe you can look at it more? https://nextjs.org/learn/seo/dynamic-import-components
4. Wrapped `Hub` page with `Suspense` component. But we could probably use this more thoroughly throughout, also didn't get much time to go further here. Maybe you can take a look? https://react.dev/reference/react/Suspense

**I recommend also just going through my commits, i might have missed something to update you on.**

**Other thoughts & notes:**
* You mentioned in your notes on the ticket ...
> Next.js allows passing Server Components as props or children to Client Components. We need to explore this approach to ensure components can be rendered on the server while still interacting with client-side providers.

I have done this mostly in nextJs by creating slots for client components that needed the `use client` directive as I mentioned before. But if we want to pass in server components from our NextJs instance into client components (aka veda-ui components), we need to leverage the **"children decomposition"** pattern which in veda-ui isn't being used much.. because it is somewhat kinda modern... and we haven't really gotten to that part of modernizing the codebase because we have been focused on breaking out. Good news is that it does look like USWDS leverages this pattern. 🙌🏼 (for example https://github.com/trussworks/react-uswds/blob/main/src/components/Modal/Modal.tsx#L191) but again we are trying to move things to USWDS so it will take some time 😅 
* In terms of SEO, much of the pages actually show up in the source code (View page source) which is a huge improvement (for example: `view-source:https://veda-ui-next-test.netlify.app/data-catalog`) because if you inspect our legacy instances (comparatively: `view-source:https://www.earthdata.nasa.gov/dashboard/data-catalog`) it doesn't display the data information. So that leads me too a curious question of what exactly are we trying to optimize?? Even if it doesn't visually render with javascript disabled, you can view the data as part of the page source which should help SEO. Or do we want faster load times?? But how much do we need to change to get a miniscule amount of faster load time, its not such a complicated app. So i was thinking about tradeoffs here and wanted to share it with you, feel free to do whatever with those thoughts though.
* Also looked into https://nextjs.org/docs/app/building-your-application/rendering/composition-patterns#moving-client-components-down-the-tree which I kindof did by pushing the providers down but didn't explore it more otherwise so feel free to see if anything can be improved here
* @hanbyul-here mentioned exploring https://nextjs.org/docs/app/building-your-application/deploying/static-exports which I didn't get to do because i didn't have time so might be worth looking at this as well. But also feel free to cap and define the ticket due to possible scope creep. Some of these things are probably worth exploring separate but your call!! 


- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
