### PR TITLE
Refactor: Simplify main component layout with utility classes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,22 +6,15 @@ import './styles/index.scss';
 import '@teamimpact/veda-ui/lib/main.css';
 
 // @NOTE: Dynamically load to ensure only CSR since these depends on VedaUI ContextProvider for routing...
-const Header = dynamic(
-  () => import('./components/header'),
-  { 
-    ssr: false,
-    loading: () => <p>Loading...</p> // @NOTE @TODO: We need a loading state!!!
-  },
-);
+const Header = dynamic(() => import('./components/header'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>, // @NOTE @TODO: We need a loading state!!!
+});
 
-const Footer = dynamic(
-  () => import('./components/footer'),
-  { 
-    ssr: false,
-    loading: () => <p>Loading...</p>
-  },
-);
-
+const Footer = dynamic(() => import('./components/footer'), {
+  ssr: false,
+  loading: () => <p>Loading...</p>,
+});
 
 export const metadata: Metadata = {
   metadataBase: new URL(baseUrl),
@@ -59,9 +52,11 @@ export default function RootLayout({
   return (
     <html lang='en'>
       <body>
-        <div className='min-viewport display-flex flex-column'>
+        <div className='minh-viewport display-flex flex-column'>
           <Header />
-          <div className='flex-fill'>{children}</div>
+          <main id='pagebody' className='flex-fill' tabIndex={-1}>
+            {children}
+          </main>
           <Footer />
         </div>
       </body>

--- a/app/lib/index.ts
+++ b/app/lib/index.ts
@@ -7,7 +7,6 @@ import {
   ReactQueryProvider,
   DevseedUiThemeProvider,
   VedaUIProvider,
-  PageMainContent,
   Block,
   Prose,
   Figure,
@@ -48,7 +47,6 @@ export {
   // Components
   CatalogView,
   PageHero,
-  PageMainContent,
   PageHeader,
   PageFooter,
   ExplorationAndAnalysis,

--- a/app/store/providers/theme.tsx
+++ b/app/store/providers/theme.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { ReactNode } from 'react';
 import { createUITheme } from '@devseed-ui/theme-provider';
-import { DevseedUiThemeProvider, PageMainContent } from '@lib';
+import { DevseedUiThemeProvider } from '@lib';
 
 // Values here should be manually synced until we consolidate all the styles to USWDS
 // Be mindful that these values are used more for VEDA UI component, not for instance
@@ -67,7 +67,7 @@ function DevseedUIThemeProvider({
 }) {
   return (
     <DevseedUiThemeProvider theme={createUITheme(VEDA_OVERRIDE_THEME)}>
-      <PageMainContent>{children}</PageMainContent>
+      {children}
     </DevseedUiThemeProvider>
   );
 }


### PR DESCRIPTION
Just a small clean up to keep the layout more straightforward. Removed the PageMainContent import and replaced it with USWDS utility classes. Also, fixed the layout to keep the footer pushed to the bottom (there was a typo with the utility class already in use). 
Previous: <img width="2032" alt="Screenshot 2025-03-05 at 11 47 53" src="https://github.com/user-attachments/assets/429186ff-5cac-4b0a-9fb6-0dbeb98932d6" />
Now: <img width="2032" alt="Screenshot 2025-03-05 at 11 47 55" src="https://github.com/user-attachments/assets/84fb8aa1-9e2c-4d53-bc3e-9a93f2557810" />


In the future, we might want to migrate the current PageMainContent component in veda-ui to USWDS and potentially reuse it here, but for now, it remains a styled component in veda-ui that's not in active use here. 

Additionally, there was a bit of back and forth with the tabIndex, added it back for accessibility (enable skip to main).