### PR TITLE
fix: Docker setup issues for Strapi demo

### DIFF
--- a/CMS/Dockerfile
+++ b/CMS/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 # Installing libvips-dev for sharp Compatibility
 RUN apk update && apk add --no-cache build-base gcc autoconf automake zlib-dev libpng-dev nasm bash vips-dev git
 ARG NODE_ENV=development
@@ -15,7 +15,7 @@ WORKDIR /opt/app
 COPY . .
 RUN chown -R node:node /opt/app
 USER node
-RUN ['yarn']
+RUN yarn
 RUN ["yarn", "build"]
 EXPOSE 1337
 CMD ["yarn", "develop"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   strapi:
     container_name: strapi
     build:
-      context: ./cms
+      context: ./CMS
       dockerfile: Dockerfile
     restart: unless-stopped
     env_file: .env
@@ -17,11 +17,11 @@ services:
       DATABASE_PASSWORD: ${DATABASE_PASSWORD}
       NODE_ENV: development
     volumes:
-      - ./cms/_docker_volumes/public/uploads:/opt/app/public/uploads
-      - ./cms/config:/opt/app/config
-      - ./cms/src:/opt/app/src
-      - ./cms/package.json:/opt/package.json
-      - ./cms/yarn.lock:/opt/yarn.lock
+      - ./CMS/_docker_volumes/public/uploads:/opt/app/public/uploads
+      - ./CMS/config:/opt/app/config
+      - ./CMS/src:/opt/app/src
+      - ./CMS/package.json:/opt/package.json
+      - ./CMS/yarn.lock:/opt/yarn.lock
     ports:
       - "1337:1337"
     depends_on:


### PR DESCRIPTION
Fixes Docker setup issues encountered when running the Strapi demo locally.

**Changes:**
- Update Node 18 → Node 20 in Dockerfile (fixes package compatibility)
- Fix Dockerfile syntax error (remove brackets from RUN command)
- Fix docker-compose.yml directory capitalization (`./cms` → `./CMS`)

**Resolves:** Package compatibility errors and directory path issues

@snmln