### PR TITLE
Fix: update readme to mark repo as beta and unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NEXT JS w. VEDA UI
+# ⛔ This repository is currently a beta release and is unsupported <br><br> NEXT JS w. VEDA UI
 
 Next.js instance that uses the [VEDA-UI components library](https://github.com/nasa-IMPACT/veda-ui) and [USWDS](https://designsystem.digital.gov/), to build applications for geospatial data visualization, storytelling and analysis.
 


### PR DESCRIPTION
Closes: https://github.com/NASA-IMPACT/veda-ui/issues/1955

## Description
Because of the current unsupported state of next-veda-ui, this PR marks this repository as an unsupported beta release.

Relates to this PR: https://github.com/NASA-IMPACT/veda-ui/pull/1956